### PR TITLE
Combining regular and weekly race mode score logic

### DIFF
--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -2,7 +2,7 @@
  * ====================NOTE====================
  *    This code was created by Daedalline,
  *   please don't claim this as your own work
- *        https://github.com/Daedalline
+ *        https://github.com
  * ============================================
  */
 
@@ -24,7 +24,11 @@ module.exports.run = async(interaction, config, maps, client) => {
     let rawdata = await fs.readFileSync('racemode_data.json');
     let data = await JSON.parse(rawdata); 
 
-    ///New Code (2/25/26) Added By Froman to combine Race Mode Regular and Weekly Submits into one command.
+    // Read the maps.json to get the current Leaderboards list
+    let mapsFileRaw = await fs.readFileSync('maps.json');
+    let mapsFileData = await JSON.parse(mapsFileRaw);
+    let leaderboardList = mapsFileData.Leaderboards || [];
+
     if(interaction.options.getSubcommand() == "submit_time"){
 
         var userID = interaction.options.getUser('user').id;
@@ -48,7 +52,6 @@ module.exports.run = async(interaction, config, maps, client) => {
         const updateMapData = (mapName) => {
             if(!data[mapName]) data[mapName] = {};
         
-            // Update if no time exists OR if the new time is faster
             if(data[mapName][userID] == undefined || totalMilliseconds < data[mapName][userID][0]) {
                 data[mapName][userID] = [totalMilliseconds, new Date().toJSON()]
                 return true; 
@@ -56,20 +59,20 @@ module.exports.run = async(interaction, config, maps, client) => {
             return false;
         }
 
-        // Keep track of which boards actually got a new record
         let updatedBoards = [];
 
+        // 1. Update the base map selected in the command
         if (updateMapData(map)) {
             updatedBoards.push(`• ${map}`);
         }
     
-        if (weeklyMapName !== null) {
+        // 2. Only update the Weekly board if the formatted name exists in the Leaderboards array
+        if (weeklyMapName !== null && leaderboardList.includes(weeklyMapName)) {
             if (updateMapData(weeklyMapName)) {
                 updatedBoards.push(`• ${weeklyMapName}`);
             }
         }
 
-        // If no boards were updated (time was slower on both)
         if(updatedBoards.length === 0) {
             var embed = new Discord.MessageEmbed()
                 .setTitle("No Time Recorded")
@@ -77,7 +80,6 @@ module.exports.run = async(interaction, config, maps, client) => {
             return await interaction.editReply({embeds: [embed]})
         }
         
-        // Save the JSON file
         var writedata = JSON.stringify(data, null, "\t");
         await fs.writeFileSync('./racemode_data.json', writedata);
     
@@ -87,13 +89,12 @@ module.exports.run = async(interaction, config, maps, client) => {
     
         var embed = new Discord.MessageEmbed()
             .setTitle("Time Recorded")
-            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}> under board: ${map}!\n\nNOTE: Time will also be added to a board with that same name where "Weekly:" and "(Race Mode)" are appended where applicable (unless name already has this format)`);
+            .setDescription(`Recorded **${timeString}** for <@${userID}>!\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
         
         return await interaction.editReply({embeds: [embed]})
     }
 
     if(interaction.options.getSubcommand() == "remove"){
-
         var userID = interaction.options.getUser('user').id
         var map = interaction.options.getString('map')
 
@@ -119,77 +120,4 @@ module.exports.run = async(interaction, config, maps, client) => {
             return await interaction.editReply({embeds: [embed]})
         }
     }
-};
-
-module.exports.autocomplete = async (interaction, Maps) => {
-    var value = interaction.options.getFocused(true);
-    var res = []
-    switch(value.name){
-        case 'map': {
-            Maps.Leaderboards.forEach(map => {
-                if((map.toLowerCase().includes(value.value.toLowerCase()) || value == "") && !(map.startsWith("Weekly") && !map.endsWith("(Race Mode)"))){
-                    res.push({
-                        name: map,
-                        value: map
-                    })
-                }
-            })
-            break;
-        }
-    }
-    interaction.respond(res.slice(0,25))
-}
-
-module.exports.info = {
-    "name": "racemode_scores",
-    "description": "Allows moderators to manage scores on the boards",
-    "options": [
-        {
-            "name": "submit_time",
-            "description": "Submit a users Race Mode score to a map by providing the total time.",
-            "type": 1,
-            "options": [
-                {
-                    "name": "user",
-                    "description": "The user to submit for",
-                    "type": 6,
-                    "required": true
-                },
-                {
-                    "name": "map",
-                    "description": "The map they got it on",
-                    "type": 3,
-                    "autocomplete": true,
-                    "required": true
-                },
-                {
-                    "name": "total_time",
-                    "description": "Total Time (mm:ss.SS)",
-                    "type": 3,
-                    "autocomplete": true,
-                    "required": true
-                },
-            ]
-        },
-        {
-            "name": "remove",
-            "description": "Remove a users Race Mode score from a map",
-            "type": 1,
-            "options": [
-                {
-                    "name": "user",
-                    "description": "The user to submit for",
-                    "type": 6,
-                    "required": true
-                },
-                {
-                    "name": "map",
-                    "description": "The map to remove it from",
-                    "type": 3,
-                    "autocomplete": true,
-                    "required": true
-                }
-            ]
-        }
-    ]
 };

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -102,13 +102,9 @@ module.exports.run = async(interaction, config, maps, client) => {
         date.setMilliseconds(totalMilliseconds);
         var timeString = date.toISOString().slice(14, 22);
     
-        // Build the list of updated boards for the response
-        let boards = `• ${map}`;
-        if (updatedWeekly) boards += `\n• ${weeklyMap}`;
-
         var embed = new Discord.MessageEmbed()
             .setTitle("Time Recorded")
-            .setDescription(`Recorded **${timeString}** for <@${userID}>\n\n**Boards Updated:**\n${boards}`);
+            .setDescription(`Recorded **${timeString}** for <@${userID}>\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
         
         return await interaction.editReply({embeds: [embed]})
     }

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -2,7 +2,7 @@
  * ====================NOTE====================
  *    This code was created by Daedalline,
  *   please don't claim this as your own work
- *        https://github.com/Daedalline
+ *        https://github.com
  * ============================================
  */
 
@@ -24,7 +24,11 @@ module.exports.run = async(interaction, config, maps, client) => {
     let rawdata = await fs.readFileSync('racemode_data.json');
     let data = await JSON.parse(rawdata); 
 
-    ///New Code (2/25/26) Added By Froman to combine Race Mode Regular and Weekly Submits into one command.
+    // Read the maps.json to get the current Leaderboards list
+    let mapsFileRaw = await fs.readFileSync('maps.json');
+    let mapsFileData = await JSON.parse(mapsFileRaw);
+    let leaderboardList = mapsFileData.Leaderboards || [];
+
     if(interaction.options.getSubcommand() == "submit_time"){
 
         var userID = interaction.options.getUser('user').id;
@@ -48,7 +52,6 @@ module.exports.run = async(interaction, config, maps, client) => {
         const updateMapData = (mapName) => {
             if(!data[mapName]) data[mapName] = {};
         
-            // Update if no time exists OR if the new time is faster
             if(data[mapName][userID] == undefined || totalMilliseconds < data[mapName][userID][0]) {
                 data[mapName][userID] = [totalMilliseconds, new Date().toJSON()]
                 return true; 
@@ -56,20 +59,20 @@ module.exports.run = async(interaction, config, maps, client) => {
             return false;
         }
 
-        // Keep track of which boards actually got a new record
         let updatedBoards = [];
 
+        // 1. Update the base map selected in the command
         if (updateMapData(map)) {
             updatedBoards.push(`• ${map}`);
         }
     
-        if (weeklyMapName !== null) {
+        // 2. Only update the Weekly board if the formatted name exists in the Leaderboards array
+        if (weeklyMapName !== null && leaderboardList.includes(weeklyMapName)) {
             if (updateMapData(weeklyMapName)) {
                 updatedBoards.push(`• ${weeklyMapName}`);
             }
         }
 
-        // If no boards were updated (time was slower on both)
         if(updatedBoards.length === 0) {
             var embed = new Discord.MessageEmbed()
                 .setTitle("No Time Recorded")
@@ -77,7 +80,6 @@ module.exports.run = async(interaction, config, maps, client) => {
             return await interaction.editReply({embeds: [embed]})
         }
         
-        // Save the JSON file
         var writedata = JSON.stringify(data, null, "\t");
         await fs.writeFileSync('./racemode_data.json', writedata);
     
@@ -87,13 +89,12 @@ module.exports.run = async(interaction, config, maps, client) => {
     
         var embed = new Discord.MessageEmbed()
             .setTitle("Time Recorded")
-            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}> under board: ${map}!\n\nNOTE: Time will also be added to a board with that same name where "Weekly:" and "(Race Mode)" are appended where applicable (unless name already has this format)`);
+            .setDescription(`Recorded **${timeString}** for <@${userID}>!\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
         
         return await interaction.editReply({embeds: [embed]})
     }
 
     if(interaction.options.getSubcommand() == "remove"){
-
         var userID = interaction.options.getUser('user').id
         var map = interaction.options.getString('map')
 
@@ -120,25 +121,6 @@ module.exports.run = async(interaction, config, maps, client) => {
         }
     }
 };
-
-module.exports.autocomplete = async (interaction, Maps) => {
-    var value = interaction.options.getFocused(true);
-    var res = []
-    switch(value.name){
-        case 'map': {
-            Maps.Leaderboards.forEach(map => {
-                if((map.toLowerCase().includes(value.value.toLowerCase()) || value == "") && !(map.startsWith("Weekly") && !map.endsWith("(Race Mode)"))){
-                    res.push({
-                        name: map,
-                        value: map
-                    })
-                }
-            })
-            break;
-        }
-    }
-    interaction.respond(res.slice(0,25))
-}
 
 module.exports.info = {
     "name": "racemode_scores",

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -90,7 +90,7 @@ module.exports.run = async(interaction, config, maps, client) => {
         if(updatedBoards.length === 0) {
             var embed = new Discord.MessageEmbed()
                 .setTitle("No Time Recorded")
-                .setDescription(`The submitted time of **${time}** is not faster than the existing record on any applicable board.`);
+                .setDescription(`The submitted time is greater than the existing time that this user is already on the Leaderboard with.`);
             return await interaction.editReply({embeds: [embed]})
         }
         
@@ -104,7 +104,7 @@ module.exports.run = async(interaction, config, maps, client) => {
     
         var embed = new Discord.MessageEmbed()
             .setTitle("Time Recorded")
-            .setDescription(`Recorded **${timeString}** for <@${userID}>\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
+            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}>\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
         
         return await interaction.editReply({embeds: [embed]})
     }

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -61,12 +61,12 @@ module.exports.run = async(interaction, config, maps, client) => {
 
         let updatedBoards = [];
 
-        // 1. Update the base map selected in the command
+        // Update the base map selected in the command
         if (updateMapData(map)) {
             updatedBoards.push(`• ${map}`);
         }
     
-        // 2. Only update the Weekly board if the formatted name exists in the Leaderboards array in maps.json
+        // Only update the Weekly board if the formatted name exists in the Leaderboards array in maps.json
         if (weeklyMapName !== null && leaderboardList.includes(weeklyMapName)) {
             if (updateMapData(weeklyMapName)) {
                 updatedBoards.push(`• ${weeklyMapName}`);
@@ -76,7 +76,7 @@ module.exports.run = async(interaction, config, maps, client) => {
         if(updatedBoards.length === 0) {
             var embed = new Discord.MessageEmbed()
                 .setTitle("No Time Recorded")
-                .setDescription(`The submitted time is greater than the existing time that this user is already on the Leaderboard with.`);
+                .setDescription(`The submitted time is either greater than or equal to the existing time that this user is already on the Leaderboard with.`);
             return await interaction.editReply({embeds: [embed]})
         }
         
@@ -122,13 +122,11 @@ module.exports.run = async(interaction, config, maps, client) => {
     }
 };
 
-// --- ADDED THIS SECTION TO FIX YOUR ERROR ---
 module.exports.autocomplete = async (interaction, Maps) => {
     var value = interaction.options.getFocused(true);
     var res = []
     switch(value.name){
         case 'map': {
-            // "Maps" is passed from your main handler, usually contains the maps.json data
             Maps.Leaderboards.forEach(map => {
                 if((map.toLowerCase().includes(value.value.toLowerCase()) || value.value == "") && !(map.startsWith("Weekly") && !map.endsWith("(Race Mode)"))){
                     res.push({

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -24,7 +24,7 @@ module.exports.run = async(interaction, config, maps, client) => {
     let rawdata = await fs.readFileSync('racemode_data.json');
     let data = await JSON.parse(rawdata); 
 
-///New Code
+    ///New Code (2/25/26) Added By Froman to combine Race Mode Regular and Weekly Submits into one command.
     if(interaction.options.getSubcommand() == "submit_time"){
 
         var userID = interaction.options.getUser('user').id;
@@ -89,54 +89,6 @@ module.exports.run = async(interaction, config, maps, client) => {
         
         return await interaction.editReply({embeds: [embed]})
     }
-
-    // OLD CODE for reference
-    // if(interaction.options.getSubcommand() == "submit_time"){
-
-    //     var userID = interaction.options.getUser('user').id;
-    //     var map = interaction.options.getString('map');
-    //     var time = interaction.options.getString('total_time');
-        
-    //     let timePattern = /\d{2}:\d{2}\.\d{2}/;
-    //     if (!timePattern.test(time)){
-    //         await interaction.reply({ephemeral: true, content: "Invalid time format. Time must be input as mm:ss.SS."})
-    //         return;
-    //     }
-    
-    //     var totalTime = interaction.options.getString('total_time').split(/:|\./);
-
-    //     await interaction.deferReply()
-        
-    //     if(!data[map]){
-    //         data[map] = {}
-    //     }
-        
-    //     var totalMilliseconds = (Number(totalTime[0]) * 60000) + (Number(totalTime[1]) * 1000) + (Number(totalTime[2]) * 10);
-
-    //     if(data[map][userID] != undefined)
-    //     {
-    //         if(data[map][userID][0] <= totalMilliseconds)
-    //         {
-    //             var embed = new Discord.MessageEmbed()
-    //             .setTitle("No Time Recorded")
-    //             .setDescription(`This time is greater than the existing time of ` + data[map][userID][0] + " milliseconds.");
-    //             return await interaction.editReply({embeds: [embed]})
-    //         }
-    //     }
-        
-    //     data[map][userID] = [totalMilliseconds, new Date().toJSON()]
-    //     var writedata = JSON.stringify(data, null, "\t");
-    //     await fs.writeFileSync('./racemode_data.json', writedata);
-        
-    //     var date = new Date(null);
-    //     date.setMilliseconds(totalMilliseconds);
-    //     var timeString = date.toISOString().slice(14, 22);
-        
-    //     var embed = new Discord.MessageEmbed()
-    //     .setTitle("Time Recorded")
-    //     .setDescription(`Recorded a time of **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}> on **${map}**`);
-    //     return await interaction.editReply({embeds: [embed]})
-    // }
 
     if(interaction.options.getSubcommand() == "remove"){
 

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -2,7 +2,7 @@
  * ====================NOTE====================
  *    This code was created by Daedalline,
  *   please don't claim this as your own work
- *        https://github.com
+ *        https://github.com/Daedalline
  * ============================================
  */
 
@@ -24,11 +24,7 @@ module.exports.run = async(interaction, config, maps, client) => {
     let rawdata = await fs.readFileSync('racemode_data.json');
     let data = await JSON.parse(rawdata); 
 
-    // Read the maps.json to get the current Leaderboards list
-    let mapsFileRaw = await fs.readFileSync('maps.json');
-    let mapsFileData = await JSON.parse(mapsFileRaw);
-    let leaderboardList = mapsFileData.Leaderboards || [];
-
+    ///New Code (2/25/26) Added By Froman to combine Race Mode Regular and Weekly Submits into one command.
     if(interaction.options.getSubcommand() == "submit_time"){
 
         var userID = interaction.options.getUser('user').id;
@@ -52,6 +48,7 @@ module.exports.run = async(interaction, config, maps, client) => {
         const updateMapData = (mapName) => {
             if(!data[mapName]) data[mapName] = {};
         
+            // Update if no time exists OR if the new time is faster
             if(data[mapName][userID] == undefined || totalMilliseconds < data[mapName][userID][0]) {
                 data[mapName][userID] = [totalMilliseconds, new Date().toJSON()]
                 return true; 
@@ -59,20 +56,20 @@ module.exports.run = async(interaction, config, maps, client) => {
             return false;
         }
 
+        // Keep track of which boards actually got a new record
         let updatedBoards = [];
 
-        // 1. Update the base map selected in the command
         if (updateMapData(map)) {
             updatedBoards.push(`• ${map}`);
         }
     
-        // 2. Only update the Weekly board if the formatted name exists in the Leaderboards array
-        if (weeklyMapName !== null && leaderboardList.includes(weeklyMapName)) {
+        if (weeklyMapName !== null) {
             if (updateMapData(weeklyMapName)) {
                 updatedBoards.push(`• ${weeklyMapName}`);
             }
         }
 
+        // If no boards were updated (time was slower on both)
         if(updatedBoards.length === 0) {
             var embed = new Discord.MessageEmbed()
                 .setTitle("No Time Recorded")
@@ -80,6 +77,7 @@ module.exports.run = async(interaction, config, maps, client) => {
             return await interaction.editReply({embeds: [embed]})
         }
         
+        // Save the JSON file
         var writedata = JSON.stringify(data, null, "\t");
         await fs.writeFileSync('./racemode_data.json', writedata);
     
@@ -89,12 +87,13 @@ module.exports.run = async(interaction, config, maps, client) => {
     
         var embed = new Discord.MessageEmbed()
             .setTitle("Time Recorded")
-            .setDescription(`Recorded **${timeString}** for <@${userID}>!\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
+            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}> under board: ${map}!\n\nNOTE: Time will also be added to a board with that same name where "Weekly:" and "(Race Mode)" are appended where applicable (unless name already has this format)`);
         
         return await interaction.editReply({embeds: [embed]})
     }
 
     if(interaction.options.getSubcommand() == "remove"){
+
         var userID = interaction.options.getUser('user').id
         var map = interaction.options.getString('map')
 
@@ -120,4 +119,77 @@ module.exports.run = async(interaction, config, maps, client) => {
             return await interaction.editReply({embeds: [embed]})
         }
     }
+};
+
+module.exports.autocomplete = async (interaction, Maps) => {
+    var value = interaction.options.getFocused(true);
+    var res = []
+    switch(value.name){
+        case 'map': {
+            Maps.Leaderboards.forEach(map => {
+                if((map.toLowerCase().includes(value.value.toLowerCase()) || value == "") && !(map.startsWith("Weekly") && !map.endsWith("(Race Mode)"))){
+                    res.push({
+                        name: map,
+                        value: map
+                    })
+                }
+            })
+            break;
+        }
+    }
+    interaction.respond(res.slice(0,25))
+}
+
+module.exports.info = {
+    "name": "racemode_scores",
+    "description": "Allows moderators to manage scores on the boards",
+    "options": [
+        {
+            "name": "submit_time",
+            "description": "Submit a users Race Mode score to a map by providing the total time.",
+            "type": 1,
+            "options": [
+                {
+                    "name": "user",
+                    "description": "The user to submit for",
+                    "type": 6,
+                    "required": true
+                },
+                {
+                    "name": "map",
+                    "description": "The map they got it on",
+                    "type": 3,
+                    "autocomplete": true,
+                    "required": true
+                },
+                {
+                    "name": "total_time",
+                    "description": "Total Time (mm:ss.SS)",
+                    "type": 3,
+                    "autocomplete": true,
+                    "required": true
+                },
+            ]
+        },
+        {
+            "name": "remove",
+            "description": "Remove a users Race Mode score from a map",
+            "type": 1,
+            "options": [
+                {
+                    "name": "user",
+                    "description": "The user to submit for",
+                    "type": 6,
+                    "required": true
+                },
+                {
+                    "name": "map",
+                    "description": "The map to remove it from",
+                    "type": 3,
+                    "autocomplete": true,
+                    "required": true
+                }
+            ]
+        }
+    ]
 };

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -59,22 +59,6 @@ module.exports.run = async(interaction, config, maps, client) => {
             return false;
         }
 
-        // // Process the standard map
-        // const updatedStandard = updateMapData(map);
-    
-        // // Process the weekly map ONLY if it was generated (i.e., the original wasn't already Weekly)
-        // let updatedWeekly = false;
-        // if (weeklyMap) {
-        //     updatedWeekly = updateMapData(weeklyMap);
-        // }
-
-        // if(!updatedStandard && !updatedWeekly) {
-        //     var embed = new Discord.MessageEmbed()
-        //         .setTitle("No Time Recorded")
-        //         .setDescription(`The time submitted is not faster than the existing record.`);
-        //     return await interaction.editReply({embeds: [embed]})
-        // }
-
         // Keep track of which boards actually got a new record
         let updatedBoards = [];
 
@@ -104,7 +88,7 @@ module.exports.run = async(interaction, config, maps, client) => {
     
         var embed = new Discord.MessageEmbed()
             .setTitle("Time Recorded")
-            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}>\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
+            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}>!\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
         
         return await interaction.editReply({embeds: [embed]})
     }

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -24,52 +24,123 @@ module.exports.run = async(interaction, config, maps, client) => {
     let rawdata = await fs.readFileSync('racemode_data.json');
     let data = await JSON.parse(rawdata); 
 
+///New Code
     if(interaction.options.getSubcommand() == "submit_time"){
 
         var userID = interaction.options.getUser('user').id;
         var map = interaction.options.getString('map');
         var time = interaction.options.getString('total_time');
-        
+    
+        // Check if the map is already a Weekly/Race Mode map
+        const isWeekly = map.startsWith("Weekly: ") && map.endsWith(" (Race Mode)");
+    
+        // Construct the Weekly map name only if it isn't one already
+        var weeklyMap = isWeekly ? null : `Weekly: ${map} (Race Mode)`;
+    
         let timePattern = /\d{2}:\d{2}\.\d{2}/;
         if (!timePattern.test(time)){
             await interaction.reply({ephemeral: true, content: "Invalid time format. Time must be input as mm:ss.SS."})
             return;
         }
-    
-        var totalTime = interaction.options.getString('total_time').split(/:|\./);
 
+        var totalTime = interaction.options.getString('total_time').split(/:|\./);
         await interaction.deferReply()
-        
-        if(!data[map]){
-            data[map] = {}
-        }
-        
+    
         var totalMilliseconds = (Number(totalTime[0]) * 60000) + (Number(totalTime[1]) * 1000) + (Number(totalTime[2]) * 10);
 
-        if(data[map][userID] != undefined)
-        {
-            if(data[map][userID][0] <= totalMilliseconds)
-            {
-                var embed = new Discord.MessageEmbed()
-                .setTitle("No Time Recorded")
-                .setDescription(`This time is greater than the existing time of ` + data[map][userID][0] + " milliseconds.");
-                return await interaction.editReply({embeds: [embed]})
-            }
-        }
+        const updateMapData = (mapName) => {
+            if(!data[mapName]) data[mapName] = {};
         
-        data[map][userID] = [totalMilliseconds, new Date().toJSON()]
+            // Update if no time exists OR if the new time is faster
+            if(data[mapName][userID] == undefined || totalMilliseconds < data[mapName][userID][0]) {
+                data[mapName][userID] = [totalMilliseconds, new Date().toJSON()]
+                return true; 
+            }
+            return false;
+        }
+
+        // Process the standard map
+        const updatedStandard = updateMapData(map);
+    
+        // Process the weekly map ONLY if it was generated (i.e., the original wasn't already Weekly)
+        let updatedWeekly = false;
+        if (weeklyMap) {
+            updatedWeekly = updateMapData(weeklyMap);
+        }
+
+        if(!updatedStandard && !updatedWeekly) {
+            var embed = new Discord.MessageEmbed()
+                .setTitle("No Time Recorded")
+                .setDescription(`The time submitted is not faster than the existing record.`);
+            return await interaction.editReply({embeds: [embed]})
+        }
+
+        // Save the JSON file
         var writedata = JSON.stringify(data, null, "\t");
         await fs.writeFileSync('./racemode_data.json', writedata);
-        
+    
         var date = new Date(null);
         date.setMilliseconds(totalMilliseconds);
         var timeString = date.toISOString().slice(14, 22);
-        
+    
+        // Build the list of updated boards for the response
+        let boards = `• ${map}`;
+        if (updatedWeekly) boards += `\n• ${weeklyMap}`;
+
         var embed = new Discord.MessageEmbed()
-        .setTitle("Time Recorded")
-        .setDescription(`Recorded a time of **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}> on **${map}**`);
+            .setTitle("Time Recorded")
+            .setDescription(`Recorded **${timeString}** for <@${userID}>\n\n**Boards Updated:**\n${boards}`);
+        
         return await interaction.editReply({embeds: [embed]})
     }
+
+    // OLD CODE for reference
+    // if(interaction.options.getSubcommand() == "submit_time"){
+
+    //     var userID = interaction.options.getUser('user').id;
+    //     var map = interaction.options.getString('map');
+    //     var time = interaction.options.getString('total_time');
+        
+    //     let timePattern = /\d{2}:\d{2}\.\d{2}/;
+    //     if (!timePattern.test(time)){
+    //         await interaction.reply({ephemeral: true, content: "Invalid time format. Time must be input as mm:ss.SS."})
+    //         return;
+    //     }
+    
+    //     var totalTime = interaction.options.getString('total_time').split(/:|\./);
+
+    //     await interaction.deferReply()
+        
+    //     if(!data[map]){
+    //         data[map] = {}
+    //     }
+        
+    //     var totalMilliseconds = (Number(totalTime[0]) * 60000) + (Number(totalTime[1]) * 1000) + (Number(totalTime[2]) * 10);
+
+    //     if(data[map][userID] != undefined)
+    //     {
+    //         if(data[map][userID][0] <= totalMilliseconds)
+    //         {
+    //             var embed = new Discord.MessageEmbed()
+    //             .setTitle("No Time Recorded")
+    //             .setDescription(`This time is greater than the existing time of ` + data[map][userID][0] + " milliseconds.");
+    //             return await interaction.editReply({embeds: [embed]})
+    //         }
+    //     }
+        
+    //     data[map][userID] = [totalMilliseconds, new Date().toJSON()]
+    //     var writedata = JSON.stringify(data, null, "\t");
+    //     await fs.writeFileSync('./racemode_data.json', writedata);
+        
+    //     var date = new Date(null);
+    //     date.setMilliseconds(totalMilliseconds);
+    //     var timeString = date.toISOString().slice(14, 22);
+        
+    //     var embed = new Discord.MessageEmbed()
+    //     .setTitle("Time Recorded")
+    //     .setDescription(`Recorded a time of **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}> on **${map}**`);
+    //     return await interaction.editReply({embeds: [embed]})
+    // }
 
     if(interaction.options.getSubcommand() == "remove"){
 

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -31,11 +31,8 @@ module.exports.run = async(interaction, config, maps, client) => {
         var map = interaction.options.getString('map');
         var time = interaction.options.getString('total_time');
     
-        // Check if the map is already a Weekly/Race Mode map
-        const isWeekly = map.startsWith("Weekly: ") && map.endsWith(" (Race Mode)");
-    
-        // Construct the Weekly map name only if it isn't one already
-        var weeklyMap = isWeekly ? null : `Weekly: ${map} (Race Mode)`;
+        const isAlreadyWeekly = map.startsWith("Weekly: ") && map.endsWith(" (Race Mode)");
+        const weeklyMapName = isAlreadyWeekly ? null : `Weekly: ${map} (Race Mode)`;
     
         let timePattern = /\d{2}:\d{2}\.\d{2}/;
         if (!timePattern.test(time)){
@@ -66,8 +63,8 @@ module.exports.run = async(interaction, config, maps, client) => {
             updatedBoards.push(`• ${map}`);
         }
     
-        if (weeklyMap && updateMapData(weeklyMap)) {
-            updatedBoards.push(`• ${weeklyMap}`);
+        if (weeklyMapName && updateMapData(weeklyMapName)) {
+            updatedBoards.push(`• ${weeklyMapName}`);
         }
 
         // If no boards were updated (time was slower on both)

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -31,7 +31,7 @@ module.exports.run = async(interaction, config, maps, client) => {
         var map = interaction.options.getString('map');
         var time = interaction.options.getString('total_time');
     
-        const isAlreadyWeekly = map.startsWith("Weekly: ") && map.endsWith(" (Race Mode)");
+        let isAlreadyWeekly = map.startsWith("Weekly: ") && map.endsWith(" (Race Mode)");
         const weeklyMapName = isAlreadyWeekly ? null : `Weekly: ${map} (Race Mode)`;
     
         let timePattern = /\d{2}:\d{2}\.\d{2}/;

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -59,22 +59,41 @@ module.exports.run = async(interaction, config, maps, client) => {
             return false;
         }
 
-        // Process the standard map
-        const updatedStandard = updateMapData(map);
+        // // Process the standard map
+        // const updatedStandard = updateMapData(map);
     
-        // Process the weekly map ONLY if it was generated (i.e., the original wasn't already Weekly)
-        let updatedWeekly = false;
-        if (weeklyMap) {
-            updatedWeekly = updateMapData(weeklyMap);
+        // // Process the weekly map ONLY if it was generated (i.e., the original wasn't already Weekly)
+        // let updatedWeekly = false;
+        // if (weeklyMap) {
+        //     updatedWeekly = updateMapData(weeklyMap);
+        // }
+
+        // if(!updatedStandard && !updatedWeekly) {
+        //     var embed = new Discord.MessageEmbed()
+        //         .setTitle("No Time Recorded")
+        //         .setDescription(`The time submitted is not faster than the existing record.`);
+        //     return await interaction.editReply({embeds: [embed]})
+        // }
+
+        // Keep track of which boards actually got a new record
+        let updatedBoards = [];
+
+        if (updateMapData(map)) {
+            updatedBoards.push(`• ${map}`);
+        }
+    
+        if (weeklyMap && updateMapData(weeklyMap)) {
+            updatedBoards.push(`• ${weeklyMap}`);
         }
 
-        if(!updatedStandard && !updatedWeekly) {
+        // If no boards were updated (time was slower on both)
+        if(updatedBoards.length === 0) {
             var embed = new Discord.MessageEmbed()
                 .setTitle("No Time Recorded")
-                .setDescription(`The time submitted is not faster than the existing record.`);
+                .setDescription(`The submitted time of **${time}** is not faster than the existing record on any applicable board.`);
             return await interaction.editReply({embeds: [embed]})
         }
-
+        
         // Save the JSON file
         var writedata = JSON.stringify(data, null, "\t");
         await fs.writeFileSync('./racemode_data.json', writedata);

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -31,7 +31,7 @@ module.exports.run = async(interaction, config, maps, client) => {
         var map = interaction.options.getString('map');
         var time = interaction.options.getString('total_time');
     
-        let isAlreadyWeekly = map.startsWith("Weekly: ") && map.endsWith(" (Race Mode)");
+        const isAlreadyWeekly = map.startsWith("Weekly: ") && map.endsWith(" (Race Mode)");
         const weeklyMapName = isAlreadyWeekly ? null : `Weekly: ${map} (Race Mode)`;
     
         let timePattern = /\d{2}:\d{2}\.\d{2}/;
@@ -63,8 +63,10 @@ module.exports.run = async(interaction, config, maps, client) => {
             updatedBoards.push(`• ${map}`);
         }
     
-        if (weeklyMapName && updateMapData(weeklyMapName)) {
-            updatedBoards.push(`• ${weeklyMapName}`);
+        if (weeklyMapName !== null) {
+            if (updateMapData(weeklyMapName)) {
+                updatedBoards.push(`• ${weeklyMapName}`);
+            }
         }
 
         // If no boards were updated (time was slower on both)

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -87,7 +87,7 @@ module.exports.run = async(interaction, config, maps, client) => {
     
         var embed = new Discord.MessageEmbed()
             .setTitle("Time Recorded")
-            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}>!\n\n**Boards Updated:**\n${updatedBoards.join("\n")}`);
+            .setDescription(`Recorded **${timeString}** (${totalMilliseconds} milliseconds) for <@${userID}> under board: ${map}!\n\nNOTE: Time will also be added to a board with that same name where "Weekly:" and "(Race Mode)" are appended where applicable (unless name already has this format)`);
         
         return await interaction.editReply({embeds: [embed]})
     }

--- a/commands/racemode_scores.js
+++ b/commands/racemode_scores.js
@@ -66,7 +66,7 @@ module.exports.run = async(interaction, config, maps, client) => {
             updatedBoards.push(`• ${map}`);
         }
     
-        // 2. Only update the Weekly board if the formatted name exists in the Leaderboards array
+        // 2. Only update the Weekly board if the formatted name exists in the Leaderboards array in maps.json
         if (weeklyMapName !== null && leaderboardList.includes(weeklyMapName)) {
             if (updateMapData(weeklyMapName)) {
                 updatedBoards.push(`• ${weeklyMapName}`);
@@ -122,6 +122,27 @@ module.exports.run = async(interaction, config, maps, client) => {
     }
 };
 
+// --- ADDED THIS SECTION TO FIX YOUR ERROR ---
+module.exports.autocomplete = async (interaction, Maps) => {
+    var value = interaction.options.getFocused(true);
+    var res = []
+    switch(value.name){
+        case 'map': {
+            // "Maps" is passed from your main handler, usually contains the maps.json data
+            Maps.Leaderboards.forEach(map => {
+                if((map.toLowerCase().includes(value.value.toLowerCase()) || value.value == "") && !(map.startsWith("Weekly") && !map.endsWith("(Race Mode)"))){
+                    res.push({
+                        name: map,
+                        value: map
+                    })
+                }
+            })
+            break;
+        }
+    }
+    interaction.respond(res.slice(0,25))
+}
+
 module.exports.info = {
     "name": "racemode_scores",
     "description": "Allows moderators to manage scores on the boards",
@@ -148,7 +169,6 @@ module.exports.info = {
                     "name": "total_time",
                     "description": "Total Time (mm:ss.SS)",
                     "type": 3,
-                    "autocomplete": true,
                     "required": true
                 },
             ]


### PR DESCRIPTION
Combining regular and weekly race mode score "Submit" command logic to automatically apply the race times to an equivalent "Weekly" board if one exists.
This is designed to save both time and reduce errors as the current process involves having to enter times twice when a "Weekly" board is there.